### PR TITLE
Small change in seeder factory that creates random book titles

### DIFF
--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -31,7 +31,7 @@ $factory->define(App\Author::class, function (Faker\Generator $faker) {
 
 $factory->define(App\Book::class, function (Faker\Generator $faker) {
     return [
-        'title' => $faker->title,
+        'title' => $faker->sentence($nbWords = 4, $variableNbWords = true),
         'author_id' => function () {
             return factory(App\Author::class)->create()->id;
         },


### PR DESCRIPTION
While setting up the API, I saw that book titles here were generated weirdly.
$faker->title generates not what it was expected to in this context ('Mr.', 'Ms.', 'Prof.' and so on). 
Changed it to generate some small lorem ipsum text.